### PR TITLE
Handle a potential corner case

### DIFF
--- a/com.gzoltar.core/src/main/java/com/gzoltar/core/runtime/Collector.java
+++ b/com.gzoltar.core/src/main/java/com/gzoltar/core/runtime/Collector.java
@@ -138,17 +138,15 @@ public class Collector {
       String hash = entry.getKey();
       boolean[] hitArray = entry.getValue().getRight();
 
-      if (!ArrayUtils.containsValue(hitArray, true)) {
-        // although the class has been loaded and instrumented, no line has been covered
-        activity.put(hash,
-            new ImmutablePair<String, boolean[]>(entry.getValue().getLeft(), hitArray));
-        continue;
-      }
-
       boolean[] cloneHitArray = new boolean[hitArray.length];
       System.arraycopy(hitArray, 0, cloneHitArray, 0, hitArray.length);
       activity.put(hash,
           new ImmutablePair<String, boolean[]>(entry.getValue().getLeft(), cloneHitArray));
+
+      if (!ArrayUtils.containsValue(hitArray, true)) {
+        // although the class has been loaded and instrumented, no line has been covered
+        continue;
+      }
 
       // reset probes
       for (int i = 0; i < hitArray.length; i++) {


### PR DESCRIPTION
### Context
Update the code to handle the following case:

Imagine a test class import a src class but does not cover any lines
in the src class.  Assume that the test class only has a test method
testExecNothing() and this method is executed before another test
method testExecSomething() in another test class.  Assume the test
method testExecSomething() covers some lines in the src class.  In the
original implementation, testExecNothing() shares the same hitArray as
testExecSomething() and this may lead to incorrect computation of the
suspiciousness scores.  For example, if testExecSomething() fails,
then all lines covered by testExecSomething() will be treated as they
are executed twice as many times as they actually are because
testExecNothing()'s hitArray is updated by testExecSomething().

### Check lists

- [ ] Unit tests
- [X] Test pass
- [X] Coding style (indentation, etc)

### Additional comments
*Please add any information of interest here below.*
