### PR TITLE
Add missing hyphen to documentation

### DIFF
--- a/com.gzoltar.cli/README.md
+++ b/com.gzoltar.cli/README.md
@@ -14,7 +14,7 @@ java -jar gzoltarcli.jar <command> [parameters]
 To see the available parameters of each command, use:
 
 ```
-java -jar gzoltarcli.jar <command> -help
+java -jar gzoltarcli.jar <command> --help
 ```
 
 


### PR DESCRIPTION
### Context
Typo in the documentation of the CLI.

### Check lists

- [x] Unit tests
- [x] Test pass
- [x] Coding style (indentation, etc)

