### PR TITLE
fix gzoltar.cli ClassCastException in Java11

### DIFF
--- a/com.gzoltar.cli/pom.xml
+++ b/com.gzoltar.cli/pom.xml
@@ -67,6 +67,12 @@
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <version>4.8.28</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/com.gzoltar.cli/pom.xml
+++ b/com.gzoltar.cli/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
-      <version>4.8.28</version>
+      <version>4.8.104</version>
     </dependency>
 
   </dependencies>

--- a/com.gzoltar.cli/src/main/java/com/gzoltar/cli/commands/RunTestMethods.java
+++ b/com.gzoltar.cli/src/main/java/com/gzoltar/cli/commands/RunTestMethods.java
@@ -21,8 +21,10 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.PrintStream;
 import java.net.URL;
+import java.net.URI;
 import java.net.URLClassLoader;
 import java.util.Properties;
+import java.util.*;
 import org.kohsuke.args4j.Option;
 import com.gzoltar.cli.Command;
 import com.gzoltar.core.test.TestMethod;
@@ -31,6 +33,8 @@ import com.gzoltar.core.test.TestTask;
 import com.gzoltar.core.test.junit.JUnitTestTask;
 import com.gzoltar.core.test.testng.TestNGTestTask;
 import com.gzoltar.core.util.ClassType;
+import io.github.classgraph.ClassGraph;
+
 
 /**
  * The <code>runTestMethods</code> command.
@@ -77,8 +81,15 @@ public class RunTestMethods extends Command {
       throw new RuntimeException(this.testMethods + " does not exist or cannot be read");
     }
 
-    final URL[] classpathURLs =
-        ((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs();
+    List<URI> classpath = new ClassGraph().getClasspathURIs();
+    List<URL> classpathUrlList = new ArrayList();
+
+    for (URI temp : classpath) {
+	classpathUrlList.add(temp.toURL());
+    }
+
+    URL[] classpathURLs = new URL[classpathUrlList.size()];
+    classpathURLs = classpathUrlList.toArray(classpathURLs);
 
     try (BufferedReader br = new BufferedReader(new FileReader(this.testMethods))) {
       String line;

--- a/com.gzoltar.cli/src/main/java/com/gzoltar/cli/commands/RunTestMethods.java
+++ b/com.gzoltar.cli/src/main/java/com/gzoltar/cli/commands/RunTestMethods.java
@@ -81,15 +81,7 @@ public class RunTestMethods extends Command {
       throw new RuntimeException(this.testMethods + " does not exist or cannot be read");
     }
 
-    List<URI> classpath = new ClassGraph().getClasspathURIs();
-    List<URL> classpathUrlList = new ArrayList();
-
-    for (URI temp : classpath) {
-	classpathUrlList.add(temp.toURL());
-    }
-
-    URL[] classpathURLs = new URL[classpathUrlList.size()];
-    classpathURLs = classpathUrlList.toArray(classpathURLs);
+    final URL[] classpathURLs = new ClassGraph().getClasspathURLs().toArray(new URL[0]);
 
     try (BufferedReader br = new BufferedReader(new FileReader(this.testMethods))) {
       String line;


### PR DESCRIPTION
### Context

When running gzoltar.cli with the latest version https://github.com/GZoltar/gzoltar/commit/51967a34817d07fb4d2a9f9c6b193be7089b842d with: 
```
java … com.gzoltar.agent.rt-1.7.3-SNAPSHOT-all.jar … com.gzoltar.cli-1.7.3-SNAPSHOT-jar-with-dependencies.jar
com.gzoltar.cli.Main runTestMethods …… --collectCoverage
```

with **Java11** projects, i get the error:
```

   ____ _____ 	_ _          	 
  / ___|__  /___ | | |_ __ _ _ __   
 | |  _  / // _ \| | __/ _` | '__|
 | |_| |/ /| (_) | | || (_| | |	 
  \____/____\___/|_|\__\__,_|_|

* Run test methods in isolation.
Exception in thread "main" java.lang.ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader (jdk.internal.loader.ClassLoaders$AppClassLoader and java.net.URLClassLoader are in module java.base of loader 'bootstrap')
    at com.gzoltar.cli.commands.RunTestMethods.execute(RunTestMethods.java:81)
    at com.gzoltar.cli.Main.execute(Main.java:105)
    at com.gzoltar.cli.Main.main(Main.java:40)
```
Therefore I did this small modification to use it with my project. Do you think this is helpful to get gzoltar.cli to work with **Java 11**?

### Check lists

- [ ] Unit tests
- [ X ] Test pass
- [ X ] Coding style (indentation, etc)
