### PR TITLE
Add filter to exclude static-initialization block in Java Interface when instrumenting

### DIFF
--- a/com.gzoltar.core/src/main/java/com/gzoltar/core/instr/filter/InterfaceStaticInitializerFilter.java
+++ b/com.gzoltar.core/src/main/java/com/gzoltar/core/instr/filter/InterfaceStaticInitializerFilter.java
@@ -1,0 +1,19 @@
+package com.gzoltar.core.instr.filter;
+
+import com.gzoltar.core.instr.Outcome;
+import javassist.CtBehavior;
+import javassist.bytecode.MethodInfo;
+
+public class InterfaceStaticInitializerFilter extends Filter {
+
+  @Override
+  public Outcome filter(final CtBehavior ctBehavior) {
+    MethodInfo methodInfo = ctBehavior.getMethodInfo();
+    if ((ctBehavior.getDeclaringClass() != null && ctBehavior.getDeclaringClass().isInterface())
+        && methodInfo.isStaticInitializer()
+        && !methodInfo.isMethod()) {
+      return Outcome.REJECT;
+    }
+    return Outcome.ACCEPT;
+  }
+}

--- a/com.gzoltar.core/src/main/java/com/gzoltar/core/instr/pass/CoveragePass.java
+++ b/com.gzoltar.core/src/main/java/com/gzoltar/core/instr/pass/CoveragePass.java
@@ -25,10 +25,7 @@ import com.gzoltar.core.instr.InstrumentationConstants;
 import com.gzoltar.core.instr.InstrumentationLevel;
 import com.gzoltar.core.instr.Outcome;
 import com.gzoltar.core.instr.actions.AnonymousClassConstructorFilter;
-import com.gzoltar.core.instr.filter.EmptyMethodFilter;
-import com.gzoltar.core.instr.filter.EnumFilter;
-import com.gzoltar.core.instr.filter.IFilter;
-import com.gzoltar.core.instr.filter.SyntheticFilter;
+import com.gzoltar.core.instr.filter.*;
 import com.gzoltar.core.model.Node;
 import com.gzoltar.core.model.NodeFactory;
 import com.gzoltar.core.runtime.Collector;
@@ -88,6 +85,9 @@ public class CoveragePass implements IPass {
     // exclude constructor of an Anonymous class as the same line number is handled by the
     // superclass
     this.filters.add(new AnonymousClassConstructorFilter());
+
+    // exclude static initialization-block of an Interface class
+    this.filters.add(new InterfaceStaticInitializerFilter());
   }
 
   @Override

--- a/com.gzoltar.core/src/test/java/com/gzoltar/core/instr/pass/TestLineInstrumentation.java
+++ b/com.gzoltar.core/src/test/java/com/gzoltar/core/instr/pass/TestLineInstrumentation.java
@@ -31,6 +31,7 @@ import org.gzoltar.examples.ProtectedModifiers;
 import org.gzoltar.examples.PublicFinalModifiers;
 import org.gzoltar.examples.PublicModifiers;
 import org.gzoltar.examples.PublicStaticModifiers;
+import org.gzoltar.examples.InterfaceFieldClass;
 import org.junit.Before;
 import org.junit.Test;
 import com.gzoltar.core.AgentConfigs;
@@ -99,6 +100,14 @@ public class TestLineInstrumentation {
   public void testProbesOfInterfaceClass() throws Exception {
     List<String> classesUnderTest = new ArrayList<String>();
     classesUnderTest.add(InterfaceClass.class.getCanonicalName());
+
+    this.test(classesUnderTest, new ArrayList<Integer>());
+  }
+
+  @Test
+  public void testProbesOfInterfaceWithFieldClass() throws Exception {
+    List<String> classesUnderTest = new ArrayList<String>();
+    classesUnderTest.add(InterfaceFieldClass.class.getCanonicalName());
 
     this.test(classesUnderTest, new ArrayList<Integer>());
   }

--- a/com.gzoltar.core/src/test/java/org/gzoltar/examples/InterfaceFieldClass.java
+++ b/com.gzoltar.core/src/test/java/org/gzoltar/examples/InterfaceFieldClass.java
@@ -1,0 +1,10 @@
+package org.gzoltar.examples;
+
+/**
+ * No static initialization-block should be created here when instrumenting the code
+ * Because an Java Interface doesn't accept any static-block in its body
+ */
+public interface InterfaceFieldClass {
+  public final String DEFAULT_STRING = "THIS_IS_DEFAULT_STRING";
+  public final String DEFAULT_STRING_WITH_NEW_OPERATOR = new String("THIS_IS_DEFAULT_STRING");
+}


### PR DESCRIPTION
### Context
When instrumenting an Interface with a field declaration, GZoltar tries to create a static-initialization block for the field if the right-hand side of the field declaration is formed by a `new` operator. Java Interface doesn't accept any static-block inside its body, therefore, it introduces errors for the tests execution phase.

Let's consider the below example (included in the patch):
```java
public interface InterfaceFieldClass {
  public final String DEFAULT_STRING = "THIS_IS_DEFAULT_STRING";
  public final String DEFAULT_STRING_WITH_NEW_OPERATOR = new String("THIS_IS_DEFAULT_STRING");
}
```

will be instrumented as
```
public interface InterfaceFieldClass {
  public final String DEFAULT_STRING = "THIS_IS_DEFAULT_STRING";
  public final String DEFAULT_STRING_WITH_NEW_OPERATOR;

  static {
    DEFAULT_STRING_WITH_NEW_OPERATOR = new String("THIS_IS_DEFAULT_STRING");
  }
}
```
This causes the compilation error for any Java version, and the error when I tried to run GZoltar on this example:
```
e - java.lang.ClassFormatError: Method $gzoltarInit in class org/gzoltar/examples/InterfaceFieldClass has illegal modifiers: 0x1009
```

I added a new filter to exclude this case in instrumenting phase.

### Check lists

- [x] Unit tests
- [x] Test pass
- [x] Coding style (indentation, etc)
